### PR TITLE
update the url of NCES

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 脚本还提供计算已使用积分的功能。点击“已选”一栏在按钮后面可以看到统计。（已适配赠送积分的情况）
 
-感谢[@xCipHanD](https://github.com/xCipHanD)提供自动高亮超出容量课程、链接教授名到[牛娃课程评价社区](https://nces.cra.moe/)、按回车键搜索课程（而不是只能点按钮）的功能。[@Cypher-Bruce](https://github.com/Cypher-Bruce)优化了积分计算的功能。
+感谢[@xCipHanD](https://github.com/xCipHanD)提供自动高亮超出容量课程、链接教授名到[牛娃课程评价社区](https://ncesnext.com/)、按回车键搜索课程（而不是只能点按钮）的功能。[@Cypher-Bruce](https://github.com/Cypher-Bruce)优化了积分计算的功能。
 
 ## 使用说明
 

--- a/SUSTechTISHelper.js
+++ b/SUSTechTISHelper.js
@@ -321,7 +321,7 @@ function addSearchLinks() {
         return $(this).text().trim() !== '';
     });
     links.each(function () {
-        $(this).attr('href', 'https://nces.cra.moe/search/?q=' + $(this).text());
+        $(this).attr('href', 'https://ncesnext.com/search/?q=' + $(this).text());
         $(this).attr('target', '_blank');
     });
 }


### PR DESCRIPTION
Nces have changed the url from nces.cra.moe to ncesnext.com .